### PR TITLE
Signup URL named route remains same after an instance of a signup error

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get    '/login',   to: 'sessions#new'
   post   '/login',   to: 'sessions#create'
   delete '/logout',  to: 'sessions#destroy'
-  resources :users do
+  resources :users, path: '/signup' do
     member do
       get :following, :followers
     end


### PR DESCRIPTION
When visiting the Signup page in a production environment, the URL is '/signup', however, if you attempt to submit the form with improper data, the render 'new' method will change the URL to '/users'. Reloading the page at this point doesn't throw an error, but for purposes of continuity it seems maintaining the URL '/signup' would be desirable.