### PR TITLE
Update gem 'aws-sdk-s3' to avoid errors on production environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ end
 
 group :production do
   gem 'pg',         '1.2.3'
-  gem 'aws-sdk-s3', '1.46.0', require: false
+  gem 'aws-sdk-s3', '1.87.0', require: false
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,8 +77,8 @@ GEM
     aws-sdk-kms (1.40.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.46.0)
-      aws-sdk-core (~> 3, >= 3.61.1)
+    aws-sdk-s3 (1.87.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
@@ -275,7 +275,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_storage_validations (= 0.8.9)
-  aws-sdk-s3 (= 1.46.0)
+  aws-sdk-s3 (= 1.87.0)
   bcrypt (= 3.1.13)
   bootsnap (= 1.4.6)
   bootstrap-sass (= 3.4.1)


### PR DESCRIPTION
I would like to suggest to update gem 'aws-sdk-s3', to avoid following error:

```
Missing service adapter for "S3"
```

To reproduce the error, run the application with:
```
config.active_storage.service = :amazon
```

Thank you.



